### PR TITLE
Require Project ID and User Permission

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,6 +12,7 @@ if (!isset($project_id)) {
     die('Project ID is a required field');
 }
 $temp_name = USERID;
+$users = REDCap::getUsers();
 if (!in_array($temp_name, $users)) {
     print "User does NOT have access to this project.";
 }

--- a/index.php
+++ b/index.php
@@ -8,7 +8,13 @@
 // large proj for testing 5749 , PID 9748 5292
 // Call the REDCap Connect file in the main "redcap" directory
 require_once "../../redcap_connect.php";
-
+if (!isset($project_id)) {
+    die('Project ID is a required field');
+}
+$temp_name = USERID;
+if (!in_array($temp_name, $users)) {
+    print "User does NOT have access to this project.";
+}
 
 // OPTIONAL: Display the project header
 require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';


### PR DESCRIPTION
Check to make sure there is a project ID and that the current user has
permission to that project.